### PR TITLE
Update jlink maven plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,6 @@ jobs:
       - name: Set up JDK 14
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 15
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: Build
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots verify

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,9 +11,9 @@
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
-      <module name="jdk-jlink-parent" target="13" />
-      <module name="jlink-error" target="13" />
-      <module name="test-jlink-client" target="13" />
+      <module name="jdk-jlink-parent" target="14" />
+      <module name="jlink-error" target="14" />
+      <module name="test-jlink-client" target="14" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/jlink/pom.xml
+++ b/jlink/pom.xml
@@ -24,7 +24,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-jlink-plugin</artifactId>
-                <version>3.0.0-alpha-2-SNAPSHOT</version>
+                <version>3.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <noHeaderFiles>true</noHeaderFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
 
-        <jdk.release>13</jdk.release>
+        <jdk.release>14</jdk.release>
 
         <guicedee.version>1.0.2.18-jre13</guicedee.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
 
-        <jdk.release>14</jdk.release>
+        <jdk.release>15</jdk.release>
 
         <guicedee.version>1.0.2.18-jre13</guicedee.version>
 


### PR DESCRIPTION
The MWE did not compile today, as the SNAPSHOT version of Maven's jlink plugin was not found. This PR updates to the latest found one. Additionally, it adds a [GitHub workflow](https://github.com/features/actions) to demonstrate the issue directly.