### PR TITLE
Use "mvn install" instead of "mvn verify"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - run: java -version
       - uses: actions/checkout@v2
-      - name: mvn verify
-        run: mvn --batch-mode --update-snapshots verify
+      - name: mvn install
+        run: mvn --batch-mode --update-snapshots install
   build-with-openj9:
     runs-on: ubuntu-latest
     strategy:
@@ -40,7 +40,7 @@ jobs:
         run: $JAVA_HOME/bin/java -version
         env:
           JAVA_HOME: ${{ steps.jdk.outputs.JAVA_HOME }}
-      - name: mvn verify
-        run: mvn --batch-mode --update-snapshots verify
+      - name: mvn install
+        run: mvn --batch-mode --update-snapshots install
         env:
           JAVA_HOME: ${{ steps.jdk.outputs.JAVA_HOME }}


### PR DESCRIPTION
Requested at https://github.com/GedMarc/JDK_Jlink_Bug/commit/511b5650c143284fab9a731a690f4440f9b084e9#commitcomment-45498732

Some notes on the parameters:

- `--batchmode`: No progress shown and other CI-disturbing things suppressed: https://stackoverflow.com/a/48929096/873282
- `--update-snaphsots`: Will update `SNAPSHOT` dependencies: https://stackoverflow.com/a/42745823/873282

Note that I got the command line from https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-java-with-maven#starting-with-a-maven-workflow-template